### PR TITLE
Use "bump" strategy for npm dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
       "groupSlug": "all-minor-patch",
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
Use "bump" strategy for npm dependencies:
In JS world we usually bump the package.json file, even if it wouldn't strictly be necessary. This strategy should do that too.